### PR TITLE
Create output folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.pickle
+Output/Scenarios.json

--- a/Backend_FTT.py
+++ b/Backend_FTT.py
@@ -183,8 +183,9 @@ def run_model():
     # Save output for all scenarios to pickle
     #TODO Setup way to retain older results?
     results =  model.output
+    os.makedirs(os.path.dirname(f"{rootdir}\\Output\\"), exist_ok=True)     # Create Output folder if it doesn't exist
     with open('Output\Results.pickle', 'wb') as f:
-        pickle.dump(results,f)
+        pickle.dump(results, f)
     # Save metadata on current model run
     with open("{}\\Output\\Scenarios.json".format(rootdir), 'w') as f:
         json.dump(scenarios_log, f)


### PR DESCRIPTION
If the Output folder doesn't exist, create it. The front-end throws a weird error if this folder does not exist. Also add output files to gitignore