### PR TITLE
fix various warnings

### DIFF
--- a/Backend_FTT.py
+++ b/Backend_FTT.py
@@ -1399,7 +1399,7 @@ if __name__ == '__main__':
 
         start = lambda: run(host='localhost', port=int(port), server='paste', reloader=False)
         thr = Thread(target=start)
-        thr.setDaemon(True)
+        thr.daemon = True
         thr.start()
 
         os.system("start {}/main".format(addr))

--- a/SourceCode/Freight/ftt_fr_main.py
+++ b/SourceCode/Freight/ftt_fr_main.py
@@ -138,7 +138,7 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):
 
     "Model Dynamics"
 
-    #Endogenous calculation starts here
+    # Endogenous calculation starts here
     if year > histend['RVKZ']:
 
         data_dt = {}
@@ -156,19 +156,16 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):
 
                 data_dt[var] = copy.deepcopy(time_lag[var])
 
-        #find if there is a regulation and if it is exceeded
+        # Find if there is a regulation and if it is exceeded
 
-        isReg =  np.zeros([len(titles['RTI']), len(titles['FTTI'])])
-        division = np.zeros([len(titles['RTI']), len(titles['FTTI'])])
-        division = divide((data_dt['RVKZ'][:, :, 0] - data['ZREG'][:, :, 0]),
-                          data_dt['ZREG'][:, :, 0])
+        division = divide((data_dt['RVKZ'][:, :, 0] - data['ZREG'][:, :, 0]), data_dt['ZREG'][:, :, 0]) # 0 when dividing by 0
         isReg = 0.5 + 0.5*np.tanh(1.5+10*division)
         isReg[data['ZREG'][:, :, 0] == 0.0] = 1.0
         isReg[data['ZREG'][:, :, 0] == -1.0] = 0.0
 
 
         for t in range(1, no_it+1):
-    #Interpolations to avoid staircase profile
+        # Interpolations to avoid staircase profile
 
             RTCO = time_lag['RZCO'][:, :, :] + (data['RZCO'][:, :, :] - time_lag['RZCO'][:, :, :]) * t * dt
             FuT = time_lag['RTFZ0'][:, :, :] + (data['RTFZ0'][:, :, :] - time_lag['RTFZ0'][:, :, :]) * t * dt

--- a/SourceCode/Heat/ftt_h_main.py
+++ b/SourceCode/Heat/ftt_h_main.py
@@ -347,13 +347,8 @@ def solve(data, time_lag, iter_lag, titles, histend, year, specs):
             data_dt[var] = copy.deepcopy(time_lag[var])
 
         # Create the regulation variable
-        isReg = np.zeros([len(titles['RTI']), len(titles['HTTI'])])
-        isReg = np.where(data['HREG'][:, :, 0] > 0.0,
-                          (0.5+0.5*np.tanh(1.5 +
-                              10*(data_dt['HEWS'][:, :, 0] - data['HREG'][:, :, 0]) 
-                                  / data['HREG'][:, :, 0])),
-                          0.0)
-
+        division = divide((data_dt['HEWS'][:, :, 0] - data['HREG'][:, :, 0]), data['HREG'][:, :, 0]) # 0 if dividing by 0
+        isReg = 0.5 + 0.5*np.tanh(1.5 +10*division)
         isReg[data['HREG'][:, :, 0] == 0.0] = 1.0
         isReg[data['HREG'][:, :, 0] == -1.0] = 0.0
 

--- a/SourceCode/Industrial_Heat/ftt_chi_main.py
+++ b/SourceCode/Industrial_Heat/ftt_chi_main.py
@@ -258,10 +258,8 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):#, #specs, co
             data_dt[var] = copy.deepcopy(time_lag[var])
 
         # Create the regulation variable #Regulate capacity #no regulations yet, isReg full of zeros
-        isReg = np.zeros([len(titles['RTI']), len(titles['ITTI'])])
-        division = np.zeros([len(titles['RTI']), len(titles['ITTI'])])
         division = divide((data_dt['IWK1'][:, :, 0] - data['IRG1'][:, :, 0]),
-                          data_dt['IRG1'][:, :, 0])
+               data_dt['IRG1'][:, :, 0])  # divide gives 0 when dividing by 0 
         isReg = 0.5 + 0.5*np.tanh(1.5+10*division)
         isReg[data['IRG1'][:, :, 0] == 0.0] = 1.0
         isReg[data['IRG1'][:, :, 0] == -1.0] = 0.0

--- a/SourceCode/Industrial_Heat/ftt_fbt_main.py
+++ b/SourceCode/Industrial_Heat/ftt_fbt_main.py
@@ -270,10 +270,7 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):#, #specs, co
             data_dt[var] = copy.deepcopy(time_lag[var])
 
         # Create the regulation variable #Regulate capacity #no regulations yet, isReg full of zeros
-        isReg = np.zeros([len(titles['RTI']), len(titles['ITTI'])])
-        division = np.zeros([len(titles['RTI']), len(titles['ITTI'])])
-        division = divide((data_dt['IWK2'][:, :, 0] - data['IRG2'][:, :, 0]),
-                          data_dt['IRG2'][:, :, 0])
+        division = divide((data_dt['IWK2'][:, :, 0] - data['IRG2'][:, :, 0]), data_dt['IRG2'][:, :, 0])  # 0 when dividing by 0
         isReg = 0.5 + 0.5*np.tanh(1.5+10*division)
         isReg[data['IRG2'][:, :, 0] == 0.0] = 1.0
         isReg[data['IRG2'][:, :, 0] == -1.0] = 0.0

--- a/SourceCode/Industrial_Heat/ftt_mtm_main.py
+++ b/SourceCode/Industrial_Heat/ftt_mtm_main.py
@@ -268,10 +268,8 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):#, #specs, co
             data_dt[var] = copy.deepcopy(time_lag[var])
 
         # Create the regulation variable #Regulate ued #no regulations yet, isReg full of zeros
-        isReg = np.zeros([len(titles['RTI']), len(titles['ITTI'])])
-        division = np.zeros([len(titles['RTI']), len(titles['ITTI'])])
         division = divide((data_dt['IWK3'][:, :, 0] - data['IRG3'][:, :, 0]),
-                          data_dt['IRG3'][:, :, 0])
+               data_dt['IRG3'][:, :, 0]) # divide gives 0 when dividing by 0
         isReg = 0.5 + 0.5*np.tanh(1.5+10*division)
         isReg[data['IRG3'][:, :, 0] == 0.0] = 1.0
         isReg[data['IRG3'][:, :, 0] == -1.0] = 0.0

--- a/SourceCode/Industrial_Heat/ftt_nmm_main.py
+++ b/SourceCode/Industrial_Heat/ftt_nmm_main.py
@@ -267,10 +267,8 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):#, #specs, co
             data_dt[var] = copy.deepcopy(time_lag[var])
 
         # Create the regulation variable #Regulate capacity #no regulations yet, isReg full of zeros
-        isReg = np.zeros([len(titles['RTI']), len(titles['ITTI'])])
-        division = np.zeros([len(titles['RTI']), len(titles['ITTI'])])
         division = divide((data_dt['IWK4'][:, :, 0] - data['IRG4'][:, :, 0]),
-                          data_dt['IRG4'][:, :, 0])
+                        data_dt['IRG4'][:, :, 0]) # divide gives 0 when dividing by 0
         isReg = 0.5 + 0.5*np.tanh(1.5+10*division)
         isReg[data['IRG4'][:, :, 0] == 0.0] = 1.0
         isReg[data['IRG4'][:, :, 0] == -1.0] = 0.0

--- a/SourceCode/Industrial_Heat/ftt_ois_main.py
+++ b/SourceCode/Industrial_Heat/ftt_ois_main.py
@@ -268,10 +268,7 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):#, #specs, co
             data_dt[var] = copy.deepcopy(time_lag[var])
 
         # Create the regulation variable #Regulate capacity #no regulations yet, isReg full of zeros
-        isReg = np.zeros([len(titles['RTI']), len(titles['ITTI'])])
-        division = np.zeros([len(titles['RTI']), len(titles['ITTI'])])
-        division = divide((data_dt['IWK5'][:, :, 0] - data['IRG5'][:, :, 0]),
-                          data_dt['IRG5'][:, :, 0])
+        division = divide((data_dt['IWK5'][:, :, 0] - data['IRG5'][:, :, 0]), data_dt['IRG5'][:, :, 0]) # 0 when dividing by 0
         isReg = 0.5 + 0.5*np.tanh(1.5+10*division)
         isReg[data['IRG5'][:, :, 0] == 0.0] = 1.0
         isReg[data['IRG5'][:, :, 0] == -1.0] = 0.0

--- a/SourceCode/Power/ftt_p_main.py
+++ b/SourceCode/Power/ftt_p_main.py
@@ -575,12 +575,10 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):
         data_dt['MWIY'] = np.zeros([len(titles['RTI']), len(titles['T2TI']), 1])
 
         # Create the regulation variable
-        isReg = np.zeros([len(titles['RTI']), len(titles['T2TI'])])
-        isReg = np.where(data['MEWR'][:, :, 0] > 0.0,
-                          (0.5 + 0.5*np.tanh(
-                              1.5+10* (data_dt['MEWK'][:, :, 0] - data['MEWR'][:, :, 0]) 
-                                  / data['MEWR'][:, :, 0])),
-                          0.0)
+        division = np.zeros_like(data_dt['MEWR'][:, :, 0])
+        np.divide((data_dt['MEWK'][:, :, 0] - data['MEWR'][:, :, 0]), data['MEWR'][:, :, 0], \
+                  out=division, where=data['MEWR'][:, :, 0]>0)
+        isReg = 0.5 + 0.5*np.tanh(1.5+10* division)
        
 
         isReg[data['MEWR'][:, :, 0] == 0.0] = 1.0

--- a/SourceCode/Transport/ftt_tr_main.py
+++ b/SourceCode/Transport/ftt_tr_main.py
@@ -417,10 +417,7 @@ def solve(data, time_lag, iter_lag, titles, histend, year, specs):
         data_dt['TWIY'] = np.zeros([len(titles['RTI']), len(titles['VTTI']), 1])
 
         #Create the regulation variable
-        isReg = np.zeros([len(titles['RTI']), len(titles['VTTI'])])
-        division = np.zeros([len(titles['RTI']), len(titles['VTTI'])])
-        division = divide((data_dt['TEWK'][:, :, 0] - data['TREG'][:, :, 0]),
-                          data_dt['TREG'][:, :, 0])
+        division = divide((data_dt['TEWK'][:, :, 0] - data['TREG'][:, :, 0]), data_dt['TREG'][:, :, 0]) # 0 when dividing by 0
         isReg = 0.5 + 0.5*np.tanh(1.5+10*division)
         isReg[data['TREG'][:, :, 0] == 0.0] = 1.0
         isReg[data['TREG'][:, :, 0] == -1.0] = 0.0

--- a/run_file.py
+++ b/run_file.py
@@ -26,19 +26,9 @@ Local library imports:
 
 """
 
-# Standard library imports
-import copy
-import os
-import sys
-
-# Third party imports
-import pandas as pd
-import numpy as np
-import matplotlib.pyplot as plt
 
 # Local library imports
 from SourceCode.model_class import ModelRun
-from SourceCode.support.divide import divide
 
 # Instantiate the run
 model = ModelRun()

--- a/settings.ini
+++ b/settings.ini
@@ -2,8 +2,8 @@
 name = FTT Stand-alone
 model_start = 2001
 model_end = 2050
-enable_modules = FTT-IH-CHI
-scenarios = S0, Rosie_test
+enable_modules = FTT-IH-CHI, FTT-Fr, FTT-P, FTT-Tr, FTT-H, FTT-IH-FBT
+scenarios = S0
 simulation_start = 2010
 simulation_end = 2050
 


### PR DESCRIPTION
Fix divide by zero warning for regulation and deprecationwarning for daemon from latest change. There are various errors I didn't spot before the previous merge when running the industrial heat submodels (shares adding up to nan, rather than one). I don't think it's caused by the most recent merge, so I've not reverted. 