### PR TITLE
Fixing divide by zero

### DIFF
--- a/SourceCode/Industrial_Heat/ftt_chi_main.py
+++ b/SourceCode/Industrial_Heat/ftt_chi_main.py
@@ -404,8 +404,8 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):#, #specs, co
                 dUtot_indirect = np.sum(dUk[:indirect_cut_off])
                 dUtot_direct = np.sum(dUk[indirect_cut_off:])
 
-                indirect_shares = (endo_ued[:indirect_cut_off] + dUk[:indirect_cut_off])/(np.sum(endo_ued[:indirect_cut_off])+dUtot_indirect)
-                direct_shares = (endo_ued[indirect_cut_off:] + dUk[indirect_cut_off:])/(np.sum(endo_ued[indirect_cut_off:])+dUtot_direct)
+                indirect_shares = divide((endo_ued[:indirect_cut_off] + dUk[:indirect_cut_off]),(np.sum(endo_ued[:indirect_cut_off])+dUtot_indirect))
+                direct_shares = divide((endo_ued[indirect_cut_off:] + dUk[indirect_cut_off:]),(np.sum(endo_ued[indirect_cut_off:])+dUtot_direct))
                 indirect_weighting = np.sum(endo_shares[:indirect_cut_off])
                 
 

--- a/SourceCode/Industrial_Heat/ftt_fbt_main.py
+++ b/SourceCode/Industrial_Heat/ftt_fbt_main.py
@@ -414,8 +414,8 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):#, #specs, co
                 dUtot_indirect = np.sum(dUk[:indirect_cut_off])
                 dUtot_direct = np.sum(dUk[indirect_cut_off:])
 
-                indirect_shares = (endo_ued[:indirect_cut_off] + dUk[:indirect_cut_off])/(np.sum(endo_ued[:indirect_cut_off])+dUtot_indirect)
-                direct_shares = (endo_ued[indirect_cut_off:] + dUk[indirect_cut_off:])/(np.sum(endo_ued[indirect_cut_off:])+dUtot_direct)
+                indirect_shares = divide((endo_ued[:indirect_cut_off] + dUk[:indirect_cut_off]),(np.sum(endo_ued[:indirect_cut_off])+dUtot_indirect))
+                direct_shares = divide((endo_ued[indirect_cut_off:] + dUk[indirect_cut_off:]),(np.sum(endo_ued[indirect_cut_off:])+dUtot_direct))
                 indirect_weighting = np.sum(endo_shares[:indirect_cut_off])
                 
 

--- a/SourceCode/Industrial_Heat/ftt_mtm_main.py
+++ b/SourceCode/Industrial_Heat/ftt_mtm_main.py
@@ -408,8 +408,8 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):#, #specs, co
                 dUtot_indirect = np.sum(dUk[:indirect_cut_off])
                 dUtot_direct = np.sum(dUk[indirect_cut_off:])
 
-                indirect_shares = (endo_ued[:indirect_cut_off] + dUk[:indirect_cut_off])/(np.sum(endo_ued[:indirect_cut_off])+dUtot_indirect)
-                direct_shares = (endo_ued[indirect_cut_off:] + dUk[indirect_cut_off:])/(np.sum(endo_ued[indirect_cut_off:])+dUtot_direct)
+                indirect_shares = divide((endo_ued[:indirect_cut_off] + dUk[:indirect_cut_off]),(np.sum(endo_ued[:indirect_cut_off])+dUtot_indirect))
+                direct_shares = divide((endo_ued[indirect_cut_off:] + dUk[indirect_cut_off:]),(np.sum(endo_ued[indirect_cut_off:])+dUtot_direct))
                 indirect_weighting = np.sum(endo_shares[:indirect_cut_off])
                 
 

--- a/SourceCode/Industrial_Heat/ftt_nmm_main.py
+++ b/SourceCode/Industrial_Heat/ftt_nmm_main.py
@@ -409,8 +409,8 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):#, #specs, co
                 dUtot_indirect = np.sum(dUk[:indirect_cut_off])
                 dUtot_direct = np.sum(dUk[indirect_cut_off:])
 
-                indirect_shares = (endo_ued[:indirect_cut_off] + dUk[:indirect_cut_off])/(np.sum(endo_ued[:indirect_cut_off])+dUtot_indirect)
-                direct_shares = (endo_ued[indirect_cut_off:] + dUk[indirect_cut_off:])/(np.sum(endo_ued[indirect_cut_off:])+dUtot_direct)
+                indirect_shares = divide((endo_ued[:indirect_cut_off] + dUk[:indirect_cut_off]),(np.sum(endo_ued[:indirect_cut_off])+dUtot_indirect))
+                direct_shares = divide((endo_ued[indirect_cut_off:] + dUk[indirect_cut_off:]),(np.sum(endo_ued[indirect_cut_off:])+dUtot_direct))
                 indirect_weighting = np.sum(endo_shares[:indirect_cut_off])
                 
 

--- a/SourceCode/Industrial_Heat/ftt_ois_main.py
+++ b/SourceCode/Industrial_Heat/ftt_ois_main.py
@@ -410,8 +410,8 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):#, #specs, co
                 dUtot_indirect = np.sum(dUk[:indirect_cut_off])
                 dUtot_direct = np.sum(dUk[indirect_cut_off:])
 
-                indirect_shares = (endo_ued[:indirect_cut_off] + dUk[:indirect_cut_off])/(np.sum(endo_ued[:indirect_cut_off])+dUtot_indirect)
-                direct_shares = (endo_ued[indirect_cut_off:] + dUk[indirect_cut_off:])/(np.sum(endo_ued[indirect_cut_off:])+dUtot_direct)
+                indirect_shares = divide((endo_ued[:indirect_cut_off] + dUk[:indirect_cut_off]),(np.sum(endo_ued[:indirect_cut_off])+dUtot_indirect))
+                direct_shares = divide((endo_ued[indirect_cut_off:] + dUk[indirect_cut_off:]),(np.sum(endo_ued[indirect_cut_off:])+dUtot_direct))
                 indirect_weighting = np.sum(endo_shares[:indirect_cut_off])
                 
 

--- a/settings.ini
+++ b/settings.ini
@@ -2,7 +2,7 @@
 name = FTT Stand-alone
 model_start = 2001
 model_end = 2050
-enable_modules = FTT-IH-CHI, FTT-Fr, FTT-P, FTT-Tr, FTT-H, FTT-IH-FBT
+enable_modules = FTT-IH-CHI, FTT-IH-FBT, FTT-IH-MTM, FTT-IH-NMM, FTT-IH-OIS2
 scenarios = S0
 simulation_start = 2010
 simulation_end = 2050


### PR DESCRIPTION
Nans in industrial heat were caused by a division by zero. Fixed by using the divide function.