### PR TITLE
Update folder name for Linux compatibility (case-sensitive filepaths)

### DIFF
--- a/SourceCode/initialise_csv_files.py
+++ b/SourceCode/initialise_csv_files.py
@@ -37,20 +37,22 @@ def get_masterfile(ftt_module, scenario):
     The filename that matches
     The middle bit of the file names for input to convert_masterfiles_to_cvs
     """
-
+    
+    # The * denotes the regionxtechnologies and last year updated part of the string
     file_pattern = f"{ftt_module}*_{scenario}.xlsx"
     matching_file = list(
         (Path('Inputs') / '_MasterFiles' / ftt_module).glob(file_pattern)
     )
 
-    # Printing warnings in case multiple files are found
+    # Printing warnings 1: in case there is no corresponding excel file
     if len(matching_file) == 0:
         print(f"Warning: No files matched the pattern for module {ftt_module} and scenario {scenario}.")
         print(f"This means {ftt_module}: {scenario} will rely only on pre-specified csv files.")
         matching_file = None
         file_root = None
         return matching_file, file_root
-
+    
+    # Printing warnings 2: in case multiple files are found
     elif len(matching_file) > 1:
         print(f"Warning: Multiple files matched the pattern for module {ftt_module} and scenario {scenario}.")
 
@@ -60,7 +62,7 @@ def get_masterfile(ftt_module, scenario):
         end_index = base_name.index(f'_{scenario}.xlsx')
         file_root = base_name[:end_index]
     except IndexError as e:
-        print("An error occurred while reading in the masterfile.")
+        print("An error occurred while finding the masterfile.")
         print(f"the ftt model and scenario: {ftt_module}, {scenario}")
         print(f"The file that triggered the error: {matching_file}")
         raise e

--- a/SourceCode/initialise_csv_files.py
+++ b/SourceCode/initialise_csv_files.py
@@ -1,6 +1,5 @@
+from pathlib import Path
 import os
-import glob
-import re
 
 
 from SourceCode.support.convert_masterfiles_to_csv import convert_masterfiles_to_csv
@@ -40,8 +39,9 @@ def get_masterfile(ftt_module, scenario):
     """
 
     file_pattern = f"{ftt_module}*_{scenario}.xlsx"
-    matching_file = glob.glob(f'Inputs/_Masterfiles/{ftt_module}/{file_pattern}')
-    #matching_file = glob.glob(f'../Inputs/_Masterfiles/{ftt_module}/{file_pattern}')
+    matching_file = list(
+        (Path('Inputs') / '_MasterFiles' / ftt_module).glob(file_pattern)
+    )
 
     # Printing warnings in case multiple files are found
     if len(matching_file) == 0:

--- a/SourceCode/initialise_csv_files.py
+++ b/SourceCode/initialise_csv_files.py
@@ -10,7 +10,7 @@ from SourceCode.support.convert_masterfiles_to_csv import convert_masterfiles_to
 def initialise_csv_files(ftt_modules, scenarios):
     """
     This function initialises the csv files for the model run.
-    It takes the enabled modules and scenarios from the settings.ini file 
+    It takes the enabled modules and scenarios from the settings.ini file
     as input and converts the masterfiles to csv files.
 
     Args:
@@ -23,26 +23,26 @@ def initialise_csv_files(ftt_modules, scenarios):
     # Get the masterfiles
     ftt_modules = ftt_modules.split(', ')
     scenarios = scenarios.split(', ')
-    
+
     model_list = generate_model_list(ftt_modules, scenarios)
-    
+
     # Convert masterfiles to csv
     convert_masterfiles_to_csv(model_list)
-    
+
     #convert_masterfiles_to_csv(models)
 
 def get_masterfile(ftt_module, scenario):
-    """Find the matching file name 
-    
+    """Find the matching file name
+
     Returns:
     The filename that matches
     The middle bit of the file names for input to convert_masterfiles_to_cvs
     """
-    
+
     file_pattern = f"{ftt_module}*_{scenario}.xlsx"
     matching_file = glob.glob(f'Inputs/_Masterfiles/{ftt_module}/{file_pattern}')
     #matching_file = glob.glob(f'../Inputs/_Masterfiles/{ftt_module}/{file_pattern}')
-    
+
     # Printing warnings in case multiple files are found
     if len(matching_file) == 0:
         print(f"Warning: No files matched the pattern for module {ftt_module} and scenario {scenario}.")
@@ -50,10 +50,10 @@ def get_masterfile(ftt_module, scenario):
         matching_file = None
         file_root = None
         return matching_file, file_root
-        
+
     elif len(matching_file) > 1:
         print(f"Warning: Multiple files matched the pattern for module {ftt_module} and scenario {scenario}.")
-    
+
     # Select part of the filename without the scenario or xlsx extension
     try:
         base_name = os.path.basename(matching_file[0]) # file name without directory
@@ -64,7 +64,7 @@ def get_masterfile(ftt_module, scenario):
         print(f"the ftt model and scenario: {ftt_module}, {scenario}")
         print(f"The file that triggered the error: {matching_file}")
         raise e
-    
+
 
     return matching_file, file_root
 
@@ -73,14 +73,14 @@ def generate_model_list(ftt_modules, scenarios):
     """
     Using the models and scenarios from the settings.ini file,
     put these into a dictionary.
-    
+
     Remove the pseudo-scenario gamma, as this should not be initialised separately
     """
     # Remove Gamma pseudo-scenario for initialisation
     scenarios = [item for item in scenarios if item != "Gamma"]
-    
+
     models = {}
-    
+
     for module in ftt_modules:
         module_scenarios = []
         for scenario in scenarios:
@@ -91,5 +91,3 @@ def generate_model_list(ftt_modules, scenarios):
         if module_scenarios:
             models[module] = [module_scenarios, file_root]
     return models
-
-    


### PR DESCRIPTION
Amended a filepath in 'SourceCode/initialise_csv_files.py', when generating input CSV files:
* from: '_Masterfiles' (note the lowercase 'f')
* to: '_MasterFiles' (uppercase 'F', matching the case of the folder name in the repository)

Linux is case sensitive (whereas Windows and macOS aren't) so this difference matters. The lowercase 'f' failed to match any data and generate input CSV files. This led to a problem when running the model because the (non-existent) input files weren't read in, leading to missing arrays during solution.

Other than this now working on Linux, all other behaviour should be unchanged.

Otherwise, the file's been tidied slightly (stripped of trailing whitespace) and uses `pathlib` for the globbing.