### PR TITLE
Update ftt_p_main.py

### DIFF
--- a/SourceCode/Power/ftt_p_main.py
+++ b/SourceCode/Power/ftt_p_main.py
@@ -571,7 +571,7 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):
             # Shares equation
             # =================================================================
             mews, mewl, mewg, mewk = shares(dt, t, T_Scal, MEWDt,
-                                            data_dt['MEWS'], data_dt['METCX'],
+                                            data_dt['MEWS'], data_dt['METC'],
                                             data_dt['MTCD'], data['MWKA'],
                                             data_dt['MES1'], data_dt['MES2'],
                                             data['MEWA'], isReg, data_dt['MEWK'],


### PR DESCRIPTION
data_dt gives the data at the previous time step. METC is the LCOE with all policies and gamma values included. METCX is the exognous LCOE (from E3ME output). We want to use endogenous LCOE values.