### PR TITLE
Create LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Climate Policy Assessment Community of Models
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
I've been reading up on this a bit more, and think I was wrong before with how restrictive the previous license was. 

* It is possible to combine the old copyleft license with a more permissive license like MIT, as long as you republish under a GLP copyleft license. 
* Both this new license and GLP allow for commercial use. GLP put a restriction on that the commercial software also needs to be freely available. This would be difficult if BNEF would want to use the software probably. We can still sell the software + support under either license, but with GLP they would still not be able to distribute any combined code. 
* There is also still the option to dual license as MIT + commercial. This means no faff for other unis / research institutes, but faff for commercial entities. Not sure how that would work for TREX.

My preference is still MIT, as it's the easiest when working with others, but wanted to clarify.