### PR TITLE
Speed up checks

### DIFF
--- a/SourceCode/Heat/ftt_h_main.py
+++ b/SourceCode/Heat/ftt_h_main.py
@@ -35,7 +35,6 @@ Functions included:
 """
 # Standard library imports
 from math import sqrt
-import warnings
 
 # Third party imports
 import numpy as np

--- a/SourceCode/Heat/ftt_h_main.py
+++ b/SourceCode/Heat/ftt_h_main.py
@@ -42,6 +42,7 @@ import numpy as np
 
 # Local library imports
 from SourceCode.support.divide import divide
+from SourceCode.support.check_market_shares import check_market_shares
 from SourceCode.Heat.ftt_h_lcoh import get_lcoh, set_carbon_tax
 from SourceCode.ftt_core.ftt_mandate import implement_mandate
 from SourceCode.ftt_core.ftt_sales_or_investments import get_sales
@@ -124,21 +125,22 @@ def solve(data, time_lag, iter_lag, titles, histend, year, specs):
                 #data['HESR'][:, :, 0] = data['HEWF'][:, :, 0]
                 #data['HESR'][r, :, 0] = data['HEWF'][r, :, 0] * data['BHTC'][r, :, c4ti["19 RES calc"]] / np.sum(data['HEWF'] * data['BHTC'][r, :, c4ti["19 RES calc"]])
 
-                # CORRECTION TO MARKET SHARES
-                # Sometimes historical market shares do not add up to 1.0
-                if (~np.isclose(np.sum(data['HEWS'][r, :, 0]), 0.0, atol=1e-9)
-                        and np.sum(data['HEWS'][r, :, 0]) > 0.0 ):
-                    data['HEWS'][r, :, 0] = np.divide(data['HEWS'][r, :, 0],
-                                                       np.sum(data['HEWS'][r, :, 0]))
+        # CORRECTION TO MARKET SHARES
+        # Sometimes historical market shares do not add up to 1.0
+        hews = data['HEWS'][:, :, 0]
+        region_sums = hews.sum(axis=1)
+        
+        needs_correction = (np.abs(region_sums - 1.0) > 1e-9) & (region_sums > 0.0)
+        data['HEWS'][needs_correction, :, 0] /= region_sums[needs_correction, np.newaxis]
                     
-            # Normalise HEWG to RHUD
-            data['HEWG'][r, :, 0] = data['HEWS'][r, :, 0] * data['RHUD'][r, 0, 0]
+        # Normalise HEWG to RHUD
+        data['HEWG'][:, :, 0] = data['HEWS'][:, :, 0] * data['RHUD'][:, :, 0]
         
         # Recalculate HEWF based on RHUD
         data['HEWF'][:, :, 0] = data['HEWG'][:, :, 0] / data['BHTC'][:, :, c4ti["9 Conversion efficiency"]]
 
         # Capacity by boiler
-        #Capacity (GW) (13th are capacity factors (MWh/kW=GWh/MW, therefore /1000)
+        # Capacity (GW) (13th are capacity factors (MWh/kW=GWh/MW, therefore /1000)
         data['HEWK'][:, :, 0] = divide(data['HEWG'][:, :, 0],
                                 data['BHTC'][:, :, c4ti["13 Capacity factor mean"]])/1000
         
@@ -430,22 +432,10 @@ def solve(data, time_lag, iter_lag, titles, histend, year, specs):
                 if (np.sum(endo_gen) + dUtot) > 0.0:
                     data['HEWS'][r, :, 0] = (endo_gen + dUk)/(np.sum(endo_gen)+dUtot)
 
-                #print("Year:", year)
-                #print("Region:", titles['RTI'][r])
-                #print("Sum of market shares:", np.sum(data['HEWS'][r, :, 0]))
 
-                if ~np.isclose(np.sum(data['HEWS'][r, :, 0]), 1.0, atol=1e-2):
-                    msg = """Sector: {} - Region: {} - Year: {}
-                    Sum of market shares do not add to 1.0 (instead: {})
-                    """.format(sector, titles['RTI'][r], year, np.sum(data['HEWS'][r, :, 0]))
-                    warnings.warn(msg)
-
-                if np.any(data['HEWS'][r, :, 0] < 0.0):
-                    msg = """Sector: {} - Region: {} - Year: {}
-                    Negative market shares detected! Critical error!
-                    """.format(sector, titles['RTI'][r], year)
-                    warnings.warn(msg)
-#                      
+            # Raise error if there are negative values 
+            # or regional market shares do not add up to one
+            check_market_shares(data['HEWS'], titles, sector, year)
 
             ############## Update variables ##################
             

--- a/SourceCode/Power/ftt_p_shares.py
+++ b/SourceCode/Power/ftt_p_shares.py
@@ -229,7 +229,7 @@ def shares_calc(dt, t, T_Scal, mewdt, mews_dt, metc_dt, mtcd_dt,
 
         # Use modified capacity and modified total capacity to recalulate market shares
         # This method will mean any capacities set to zero will result in zero shares
-        # It avoids negatuve shares
+        # It avoids negative shares
         # All other capacities will be stretched, depending on the magnitude of dUtot and how much of a change this makes to total capacity
         # If dUtot is small and implemented in a way which will not under or over estimate capacity greatly, MWKA is fairly accurate
 

--- a/SourceCode/Transport/ftt_tr_main.py
+++ b/SourceCode/Transport/ftt_tr_main.py
@@ -32,7 +32,6 @@ Functions included:
 
 # Standard library imports
 from math import sqrt
-import warnings
 
 # Third party imports
 import numpy as np

--- a/SourceCode/Transport/ftt_tr_main.py
+++ b/SourceCode/Transport/ftt_tr_main.py
@@ -39,6 +39,7 @@ import numpy as np
 
 # Local library imports
 from SourceCode.support.divide import divide
+from SourceCode.support.check_market_shares import check_market_shares
 from SourceCode.Transport.ftt_tr_lcot import get_lcot
 from SourceCode.ftt_core.ftt_sales_or_investments import get_sales
 from SourceCode.Transport.ftt_tr_survival import survival_function, add_new_cars_age_matrix
@@ -146,10 +147,9 @@ def solve(data, time_lag, iter_lag, titles, histend, year, specs):
 
             # Correction to market shares
             # Sometimes historical market shares do not add up to 1.0
-            if (~np.isclose(np.sum(data['TEWS'][r, :, 0]), 1.0, atol=1e-9)
-                    and np.sum(data['TEWS'][r, :, 0]) > 0.0):
-                data['TEWS'][r, :, 0] = np.divide(data['TEWS'][r, :, 0],
-                                                  np.sum(data['TEWS'][r, :, 0]))
+            share_sum = np.sum(data['TEWS'][r, :, 0])
+            if (abs(share_sum - 1.0) > 1e-9) and (share_sum > 0.0):
+                data['TEWS'][r, :, 0] /= share_sum
 
             # Computes initial values for the capacity factor, numbers of
             # vehicles by technology and distance driven
@@ -386,18 +386,10 @@ def solve(data, time_lag, iter_lag, titles, histend, year, specs):
                 data['TEWS'][r, :, 0] = (
                     endo_capacity + dUk) / (np.sum(endo_capacity) + dUtot)
 
-                # Check shares sum to 1
-                if ~np.isclose(np.sum(data['TEWS'][r, :, 0]), 1.0, atol=1e-3):
-                    msg = f"""Sector: {sector} - Region: {titles['RTI'][r]} - Year: {year}
-                    Sum of market shares do not add to 1.0 (instead: {np.sum(data['TEWS'][r, :, 0])})
-                    """
-                    warnings.warn(msg)
-
-                if np.any(data['TEWS'][r, :, 0] < 0.0):
-                    msg = f"""Sector: {sector} - Region: {titles['RTI'][r]} - Year: {year}
-                    Negative market shares detected! Critical error!
-                    """
-                    warnings.warn(msg)
+            # Raise error if there are negative values 
+            # or regional market shares do not add up to one
+            check_market_shares(data['TEWS'], titles, sector, year)
+                
 
             ############## Update variables ##################
 

--- a/SourceCode/support/check_market_shares.py
+++ b/SourceCode/support/check_market_shares.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Jun 27 08:46:30 2025
+
+@author: Femke
+"""
+
+import numpy as np
+
+def check_market_shares(shares, titles, sector, year):
+    '''Checks if the region sum of market shares is one and whether there
+    are regions and technologies with negative shares.
+    
+    Raises ValueErrors if there are problems'''
+    
+    # TODO: explore why FTT:Tr doesn't quite add up to 1 (1e-5 does not work)
+    total_shares = shares[:, :, 0].sum(axis=1)
+    invalid = np.abs(total_shares - 1.0) > 1e-4
+    if np.any(invalid):
+        regions = [titles['RTI'][r] for r in np.where(invalid)[0]]
+        shares = [f"{total_shares[r]:.4f}" for r in np.where(invalid)[0]]
+        messages = [f"{region} (sum={share})" for region, share in zip(regions, shares)]
+        raise ValueError(
+            f"Sector: {sector} - Year: {year} - Invalid market share sums in regions: "
+            + ", ".join(messages)
+        )
+    
+    # Check for negative market shares
+    negatives = (shares[:, :, 0] < 0.0).any(axis=1)
+    if np.any(negatives):
+        regions = [titles['RTI'][r] for r in np.where(negatives)[0]]
+        raise ValueError(
+            f"Sector: {sector} - Year: {year} - Negative market shares detected in regions: "
+            + ", ".join(regions)
+        )

--- a/SourceCode/support/divide.py
+++ b/SourceCode/support/divide.py
@@ -20,5 +20,6 @@ def divide(a, b):
         a, b,
         # Use `zeros()`, not `zeros_like()`, to ensure type is `float`
         out=np.zeros(a.shape),
-        where=~np.isclose(b, 0),
+        # Use absolute value of b, rather than isclose, for performance
+        where=np.abs(b) > 1e-12, 
         casting='unsafe')


### PR DESCRIPTION
Isclose is very expensive, and not needed here. It checks relative and absolutely closeness, but we do not need relative checks
* For shares checks, it's always compared to 1 and 0
* For divide, it's always checked to 0.

Leave freight comparison, as this will conflict with future improvements..