### PR TITLE
Simplify sales function

### DIFF
--- a/SourceCode/Power/ftt_p_main.py
+++ b/SourceCode/Power/ftt_p_main.py
@@ -460,10 +460,6 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):
             e_demand = MEWDt * 1000/3.6
 
             
-            # For checking
-            if t == no_it:
-                data["MEWD"] = np.copy(data['MEWDX'])
-            
             # Find valid regions (where demand > 0)
             valid_regions = np.where(MEWDt > 0.0)[0]
             
@@ -568,15 +564,11 @@ def solve(data, time_lag, iter_lag, titles, histend, year, domain):
             # Update emissions
             data['MEWE'][:, :, 0] = data['MEWG'][:, :, 0] * data['BCET'][:, :, c2ti['15 Emissions (tCO2/GWh)']] / 1e6
             
-            # Update investment. Note that sum(mewi_t) not exactly mewi
-            _, mewi_t = get_sales(
+            # Update investment (up to timestep t, and in timestep t)
+            data["MEWI"], mewi_t = get_sales(
                 data["MEWK"], data_dt["MEWK"], time_lag["MEWK"], data["MEWI"],
                 data['BCET'][:, :, c2ti["9 Lifetime (years)"]], dt)
             
-            data["MEWI"] = get_sales_yearly(
-                data["MEWK"], time_lag["MEWK"], data["MEWI"],
-                data['BCET'][:, :, c2ti["9 Lifetime (years)"]])
-
             # TODO: review, compute cost of early scrapping
             mesc_vec, melf_vec = early_scrapping_costs(data, data_dt, c2ti)
             # =============================================================

--- a/settings.ini
+++ b/settings.ini
@@ -2,7 +2,7 @@
 name = FTT Stand-alone
 model_start = 2001
 model_end = 2050
-enable_modules = FTT-H
+enable_modules = FTT-P
 scenarios = S0
 simulation_start = 2010
 simulation_end = 2050


### PR DESCRIPTION
To align with E3ME, I was using a slightly less accurate way of computing yearly sales (once, instead of adding up timesteps). Removing as speed is priority now, and no need to put in inaccuracies