### PR TITLE
Adjust the GUI results page preventing overflow

### DIFF
--- a/GUI/page_results.py
+++ b/GUI/page_results.py
@@ -135,8 +135,11 @@ def render_results_page():
                                         for models_tuple, scen_list in sorted(
                                             models_by_scenario.items(), key=lambda x: (-len(x[0]), x[0])
                                         ):
+                                            # shorten long scenario lists for display if too many
+                                            if len(scen_list) > 3:
+                                                scen_list = scen_list[:3] + ['...']
                                             if models_tuple:
-                                                with ui.row().classes('w-full h-full gap-2 items-center'):
+                                                with ui.row().classes('w-full h-full gap-2 overflow-auto'):
                                                     for model in models_tuple:
                                                         color = model_colors.get(model, 'gray')
                                                         ui.badge(model).props(f'color={color}').classes('text-sm')
@@ -145,7 +148,7 @@ def render_results_page():
                                                 ui.badge('No models').props('color=red').classes('text-sm')
                             
                                 # Models run display
-                                models_container = ui.column().classes('w-full overflow-y-auto gap-2 px-1 py-2 max-h-48')
+                                models_container = ui.column().classes('w-[calc(50vw-8rem)] overflow-y-auto gap-2 px-1 py-2 max-h-48')
 
                             # Right side: Scenario section
                             with ui.column().classes('flex-1 items-start overflow-y-auto'):


### PR DESCRIPTION
Under model results loaded, only a max of 3 scenarios are shown for each model combination.

Also adjusted some of the properties of that container so that it should not 'jump' out of the tab.

Tested on both 24in monitor and 14in laptop.