### PR TITLE
Fix marginal costs

### DIFF
--- a/SourceCode/Power/ftt_p_lcoe.py
+++ b/SourceCode/Power/ftt_p_lcoe.py
@@ -217,10 +217,8 @@ def get_lcoe(data, titles):
     data['MCOC'][:, :, 0] = bcet[:, :, 0]
     data['MCFC'][:, :, 0] = bcet[:, :, c2ti['11 Decision Load Factor']]  # Marginal capacity factor
 
-    mwmc_condition = np.rint(data['MSAL'][:, 0, 0]) > 1
-    data['MWMC'][:, :, 0] = np.where(mwmc_condition[:, None], 
-                                 bcet[:, :, 0] + bcet[:, :, 4] + bcet[:, :, 6] + (data['MSSP'][:, :, 0] + data['MLSP'][:, :, 0]) / 1000,
-                                 bcet[:, :, 0] + bcet[:, :, 4] + bcet[:, :, 6])
+    # Marginal costs
+    data['MWMC'][:, :, 0] = bcet[:, :, 0] + bcet[:, :, 4] + bcet[:, :, 6]
 
     data['MMCD'][:, :, 0] = np.sqrt(bcet[:, :, 1] ** 2 + bcet[:, :, 5] ** 2 + bcet[:, :, 7] ** 2)
 

--- a/Utilities/titles/VariableListing.csv
+++ b/Utilities/titles/VariableListing.csv
@@ -52,7 +52,7 @@ MLSC,FTT:Power long-term storage capacity (GW),GW,RTI,NA,NA,TIME,FTT-P,-,-,2001,
 MLLB,FTT:Power load factors (%) by tech x load band,%,RTI,T2TI,LBTI,TIME,FTT-P,-,-,2001,-
 Gen_by_lb,Generation by technology and load band,GWh,RTI,T2TI,LBTI,TIME,FTT-P,-,-,2001,-
 MLCC,Long-term storage levelised cost estimate,2013$/GWh,RTI,NA,NA,TIME,FTT-P,,,2012,
-MLBP,FTT:Power Maximum marginal costs per load band (serves as the price),,RTI,LBTI,NA,TIME,FTT-P,,,2001,
+MLBP,FTT:Power Average marginal costs per load band (serves as the price),$/MWh,RTI,LBTI,NA,TIME,FTT-P,,,2001,
 MLB1,Normalised residual load band heights (-),%,RTI,LBTI,NA,TIME,FTT-P,,,2001,
 MLB0,Cumulative residual load band heights (-),%,RTI,LBTI,NA,TIME,FTT-P,,,2001,
 MKLB,Capacity by load band,GW,RTI,LBTI,NA,TIME,FTT-P,-,-,2001,-


### PR DESCRIPTION
The calculations were indicating that storage levelised costs (including investment costs) had to be added to variable renewable costs, which gave higher marginal costs for renewables than for many fossil fuel costs, which is unrealistic. The marginal cost of storage is much lower. If / when we do storage as a separate tech, we can include this. 