### PR TITLE
Fix double counting in marginal pricing

### DIFF
--- a/SourceCode/Power/ftt_p_fuel_price.py
+++ b/SourceCode/Power/ftt_p_fuel_price.py
@@ -235,10 +235,7 @@ def get_marginal_fuel_prices_mewp(data, titles, Svar):
 
                 # Only select technologies with non-zero generation
                 where_condition = gen_by_lb[:, LB] > 0.0
-                mc_tech_by_lb[where_condition] = (
-                    data["MWMC"][r, :, 0][where_condition]
-                    - data["BCET"][r, :, 0][where_condition]
-                )
+                mc_tech_by_lb[where_condition] = data["MWMC"][r, :, 0][where_condition]
 
                 # Weighted average marginal cost
                 if np.sum(gen_by_lb[:, LB]) > 0.0:

--- a/SourceCode/Power/ftt_p_fuel_price.py
+++ b/SourceCode/Power/ftt_p_fuel_price.py
@@ -249,13 +249,13 @@ def get_marginal_fuel_prices_mewp(data, titles, Svar):
                     # Adjust prices for higher transmission costs
                     data["MLBP"][r, LB, 0] *= 1.3
                 
-                # Smooth the baseload price trajectory towards VRE when baseload under 5% height 
-                if data['MLB1'][r, 0, 0] < 0.05:
-                    baseload_weight = data['MLB1'][r, 0, 0] / 0.05
-                    vre_weight = 1 - baseload_weight
-                    data["MLBP"][r, 0, 0] = (data["MLBP"][r, 0, 0] * baseload_weight
-                                             + np.max(data["MWMC"][r, :, 0] * Svar[r, :]) * vre_weight)  
-            
+            # Smooth the baseload price trajectory towards VRE when baseload under 5% height
+            if data["MLB1"][r, 0, 0] < 0.05:
+                baseload_weight = np.clip(data["MLB1"][r, 0, 0] / 0.05, 0.0, 1.0)
+                vre_weight = 1.0 - baseload_weight
+                vre_price = np.max(data["MWMC"][r, :, 0] * Svar[r, :])
+                data["MLBP"][r, 0, 0] = data["MLBP"][r, 0, 0] * baseload_weight + vre_price * vre_weight
+
             # Adjust load band prices for start-up costs, and low efficiency in peak load bands
             data["MLBP"][r, 4, 0] *= 1.35  # Back-up reserves - highest start-up costs
             data["MLBP"][r, 3, 0] *= 1.2

--- a/SourceCode/Power/ftt_p_fuel_price.py
+++ b/SourceCode/Power/ftt_p_fuel_price.py
@@ -243,27 +243,25 @@ def get_marginal_fuel_prices_mewp(data, titles, Svar):
                 # Weighted average marginal cost
                 if np.sum(gen_by_lb[:, LB]) > 0.0:
                     data["MLBP"][r, LB, 0] = np.sum(mc_tech_by_lb * gen_by_lb[:, LB]) / np.sum(gen_by_lb[:, LB])
+                # If the load band is now empty, set the price to variable renewables
                 else:
                     data["MLBP"][r, LB, 0] = np.max(data["MWMC"][r, :, 0] * Svar[r, :])
-
-            # Adjust load band prices for start-up costs and VRE transmission
-            data["MLBP"][r, 4, 0] *= 1.25  # Peak load - highest start-up costs
-            data["MLBP"][r, 3, 0] *= 1.1
+                    # Adjust prices for higher transmission costs
+                    data["MLBP"][r, LB, 0] *= 1.3
+                
+                # Smooth the baseload price trajectory towards VRE when baseload under 5% height 
+                if data['MLB1'][r, 0, 0] < 0.05:
+                    baseload_weight = data['MLB1'][r, 0, 0] / 0.05
+                    vre_weight = 1 - baseload_weight
+                    data["MLBP"][r, 0, 0] = (data["MLBP"][r, 0, 0] * baseload_weight
+                                             + np.max(data["MWMC"][r, :, 0] * Svar[r, :]) * vre_weight)  
+            
+            # Adjust load band prices for start-up costs, and low efficiency in peak load bands
+            data["MLBP"][r, 4, 0] *= 1.35  # Back-up reserves - highest start-up costs
+            data["MLBP"][r, 3, 0] *= 1.2
             data["MLBP"][r, 2, 0] *= 1.05
-            data["MLBP"][r, 5, 0] *= 1.3   # VRE - higher transmission costs
-
-            vre_weight = 0.0
-            non_vre_price = 0.0
-
-            # VRE weight increases above 40% penetration
-            share_VRE = np.sum(data["MEWG"][r, :, 0] * Svar[r, :]) / max(np.sum(data["MEWG"][r, :]), 1e-10)
-            if share_VRE > 0.40:
-                vre_weight = (1.0 / 0.6) * share_VRE - 2.0 / 3.0
-
-            if np.sum(np.array([gen_by_lb[:, LB] for LB in range(n_loadbands - 1)])) > 0.0:
-                non_vre_price = np.sum(data["MLBP"][r, :n_loadbands-1, 0] * non_vre_lb_weight)
-
-            data["MEWP"][r, 7, 0] = vre_weight * data["MLBP"][r, 5, 0] + (1.0 - vre_weight) * non_vre_price
+           
+            data["MEWP"][r, 7, 0] = np.sum(data["MLBP"][r, :n_loadbands-1, 0] * non_vre_lb_weight)
 
 
     return data

--- a/Utilities/titles/VariableListing.csv
+++ b/Utilities/titles/VariableListing.csv
@@ -52,7 +52,7 @@ MLSC,FTT:Power long-term storage capacity (GW),GW,RTI,NA,NA,TIME,FTT-P,-,-,2001,
 MLLB,FTT:Power load factors (%) by tech x load band,%,RTI,T2TI,LBTI,TIME,FTT-P,-,-,2001,-
 Gen_by_lb,Generation by technology and load band,GWh,RTI,T2TI,LBTI,TIME,FTT-P,-,-,2001,-
 MLCC,Long-term storage levelised cost estimate,2013$/GWh,RTI,NA,NA,TIME,FTT-P,,,2012,
-MLBP,FTT:Power Maximum marginal costs per load band (serves as the price),,RTI,LBTI,NA,TIME,FTT-P,,,2001,
+MLBP,FTT:Power Marginal costs per load band (serves as the price),$/MWh,RTI,LBTI,NA,TIME,FTT-P,,,2001,
 MLB1,Normalised residual load band heights (-),%,RTI,LBTI,NA,TIME,FTT-P,,,2001,
 MLB0,Cumulative residual load band heights (-),%,RTI,LBTI,NA,TIME,FTT-P,,,2001,
 MKLB,Capacity by load band,GW,RTI,LBTI,NA,TIME,FTT-P,-,-,2001,-
@@ -379,3 +379,5 @@ Battery cap additions,Capacity additions per timestep per model,GWh,models_w_bat
 Cumulative total batcap,Cumulative capacity over batteries across sectors,GWh,NA,NA,NA,TIME,General,-,-,2020,-
 ZEVC,Starting non-battery costs of a truck,USD/veh,RTI,FTTI,NA,TIME,FTT-Fr,,,2001,
 Battery price,Battery prices for transport and freight,USD/kWh,RTI,NA,NA,TIME,General,2018,2023,2018,
+Smart meter uptake,Fraction of households with smart meters,,RTI,NA,NA,TIME,General,2018,2022,2018,
+TOU tariff uptake,Fraction of households with EVs or HPs that have TOU tariffs,,RTI,NA,NA,TIME,General,2018,2023,2018,


### PR DESCRIPTION
The old marginal pricing included a switch to VRE prices as baseload disappeared, but also an additional VRE weight as VRE shares increased. This was double counting. Instead, I've reverted back the the RLDC logic, but introduced a smoothing so that we don't have an abrupt regime shift when VRE takes over from baseload.

I've further increased the costs of the reserves and peak prices, as in practice these prices have been going up incredibly rapidly. This might still be too little.