### PR TITLE
More robust python call

### DIFF
--- a/launch_frontend.bat
+++ b/launch_frontend.bat
@@ -8,7 +8,7 @@ if %errorlevel%==0 (
 python run_frontend.py
 
 if %errorlevel% neq 0 (
-    py run_frontend.py
+    python run_frontend.py
 )
 
 pause


### PR DESCRIPTION
The py abbreviation only works with the official WIndows installer, not in general