### PR TITLE
Automatically select latest Results file

### DIFF
--- a/GUI/page_results.py
+++ b/GUI/page_results.py
@@ -55,7 +55,7 @@ def render_results_page():
                                 pickle_display_names = list(pickle_files_map.keys())
                                 latest_pickle_file = engine.get_latest_pickle_file()
                                 initial_result_files = state.selected_result_files
-                                if latest_pickle_file and latest_pickle_file not in initial_result_files:
+                                if latest_pickle_file and not initial_result_files:
                                     initial_result_files = [latest_pickle_file]
                                     state.selected_result_files = initial_result_files
                                 

--- a/GUI/page_results.py
+++ b/GUI/page_results.py
@@ -53,13 +53,18 @@ def render_results_page():
                                 # Get available pickle files from engine (dict: display_name -> filename)
                                 pickle_files_map = engine.get_available_pickle_files()
                                 pickle_display_names = list(pickle_files_map.keys())
+                                latest_pickle_file = engine.get_latest_pickle_file()
+                                initial_result_files = state.selected_result_files
+                                if latest_pickle_file and latest_pickle_file not in initial_result_files:
+                                    initial_result_files = [latest_pickle_file]
+                                    state.selected_result_files = initial_result_files
                                 
                                 with ui.column().classes('w-[calc(50vw-8rem)] overflow-auto items-center'):                                    
                                     file_picker = ui.select(
                                         options=pickle_display_names,
                                         label='Available Files',
                                         multiple=True,
-                                        value=state.selected_result_files,
+                                        value=initial_result_files,
                                         with_input=True,
                                         on_change=lambda e: load_pickles()
                                     ).classes('w-full overflow-hidden').props('dense use-chips')

--- a/GUI/results_engine.py
+++ b/GUI/results_engine.py
@@ -76,6 +76,19 @@ class ResultsEngine:
             files = sorted([f.name for f in output_dir.glob('*.pickle')])
             return {f.replace('.pickle', ''): f for f in files}
         return {}
+
+    def get_latest_pickle_file(self):
+        """Get the display name of the most recently modified pickle file."""
+        output_dir = Path('Output')
+        if not output_dir.exists():
+            return None
+
+        files = list(output_dir.glob('*.pickle'))
+        if not files:
+            return None
+
+        latest_file = max(files, key=lambda f: f.stat().st_mtime)
+        return latest_file.name.replace('.pickle', '')
     
     def load_pickle_files(self, filenames):
         """

--- a/GUI/results_engine.py
+++ b/GUI/results_engine.py
@@ -83,12 +83,20 @@ class ResultsEngine:
         if not output_dir.exists():
             return None
 
-        files = list(output_dir.glob('*.pickle'))
-        if not files:
-            return None
+        latest_file = None
+        latest_mtime = None
 
-        latest_file = max(files, key=lambda f: f.stat().st_mtime)
-        return latest_file.name.replace('.pickle', '')
+        for file in output_dir.glob('*.pickle'):
+            try:
+                mtime = file.stat().st_mtime
+            except OSError:
+                continue
+
+            if latest_mtime is None or mtime > latest_mtime:
+                latest_file = file
+                latest_mtime = mtime
+
+        return latest_file.stem if latest_file else None
     
     def load_pickle_files(self, filenames):
         """


### PR DESCRIPTION
Fixes #330.

This PR updates the Results page so the most recently modified pickle file in the Output folder is selected automatically when the Results page opens. This means that after running a new set of scenarios, the latest output file is loaded without requiring the user to manually select it first.

Users can still add other results files manually if they want to compare multiple outputs.

Tested locally by running FTT-P / S0 with new output names `sanatparida_test03` and `sanatparida_test04`. After each run, the latest output file was selected automatically in Results → Load Files, and I could still manually add another result file for comparison.