### PR TITLE
Create pypi-publish.yml

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -25,6 +25,23 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Verify version matches release tag
+        run: |
+          python - <<'PY'
+          import os, tomllib
+
+          tag = os.environ.get("GITHUB_REF_NAME", "")
+          tag = tag[1:] if tag.startswith("v") else tag
+
+          with open("pyproject.toml", "rb") as f:
+              version = tomllib.load(f)["project"]["version"]
+
+          if version != tag:
+              raise SystemExit(
+                  f"pyproject.toml version {version!r} does not match release tag {tag!r}"
+              )
+          PY
+
       - name: Install build tools
         run: python -m pip install --upgrade pip build
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build-and-publish:
+    name: Build and publish package
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
Have VS code create a pypi publish file, so I don't need to manually do this each time. 

The way I understand it, this still requires me to change something on the PyPI website, and I have to manually bump the version number. 