### PR TITLE
Add stop button for running simulations

### DIFF
--- a/GUI/page_run.py
+++ b/GUI/page_run.py
@@ -90,12 +90,12 @@ def render_run_page():
     async def start_run():
         nonlocal update_timer, stop_event
         
-        # Disable run button and set running state (disables navigation buttons)
+        # Prepare cancellation state before making the Stop button clickable
         run_btn.disable()
-        stop_btn.enable()
-        set_inputs_enabled(False)
         state.is_running = True
         stop_event = Event()
+        set_inputs_enabled(False)
+        stop_btn.enable()
         progress_bar.set_value(0)
         log_console.clear()
         
@@ -125,9 +125,11 @@ def render_run_page():
             ui.notify('Run Complete', type='positive')
             
         except Exception as e:
+            from ftt_source.model_class import RunCancelledError
+
             await update_from_queues()  # flush any pending log messages first
             log_console.push("-" * 40)
-            if str(e) == "Run cancelled by user":
+            if isinstance(e, RunCancelledError):
                 log_console.push("Run cancelled by user.")
                 ui.notify('Run cancelled', type='warning')
             else:

--- a/GUI/page_run.py
+++ b/GUI/page_run.py
@@ -71,7 +71,8 @@ def render_run_page():
         if stop_event and state.is_running:
             stop_event.set()
             stop_btn.disable()
-            log_console.push("Stop requested. Waiting for the current safe checkpoint...")
+            # Route through log_queue (not a direct push) so it stays in order with backend messages
+            log_queue.put("Stopping run...")
     
     async def update_from_queues():
         """Pull updates from queues and update UI"""
@@ -183,12 +184,16 @@ def execute_model(models, end_year, scenarios, output_name, progress_queue, log_
         config.write(configfile)
     
     # Import RunFTT only when needed (lazy loading for faster GUI startup)
-    from ftt_source.model_class import RunFTT
+    from ftt_source.model_class import RunFTT, RunCancelledError
     
     # Create model with callbacks
     model = RunFTT(progress_callback=progress_callback, log_callback=log_callback,
                    stop_callback=stop_callback)
-    
+
+    # Input loading isn't cancellable, so stop may already have been requested by now
+    if stop_event.is_set():
+        raise RunCancelledError("Run cancelled by user")
+
     log_queue.put("Running model...")
     model.run()
     

--- a/GUI/page_run.py
+++ b/GUI/page_run.py
@@ -3,6 +3,7 @@ import pickle
 import configparser
 from pathlib import Path
 from queue import Queue
+from threading import Event
 
 from .shared import shared_layout
 from .state import state
@@ -40,8 +41,10 @@ def render_run_page():
                                                             lambda value: len(str(value)) > 0})
 
                 ui.separator().classes('my-4')
-                with ui.row().classes('w-full justify-center'):
+                with ui.row().classes('w-full justify-center gap-4'):
                     run_btn = ui.button('Run', on_click=lambda: start_run()).classes('w-30 h-14 text-lg')
+                    stop_btn = ui.button('Stop', on_click=lambda: request_stop(), color='red').classes('w-30 h-14 text-lg')
+                    stop_btn.disable()
 
         # Right col (1/3 width)
         with ui.column().classes('w-1/3'):
@@ -57,6 +60,18 @@ def render_run_page():
     progress_queue = Queue()
     log_queue = Queue()
     update_timer = None
+    stop_event = None
+
+    def set_inputs_enabled(enabled):
+        inputs = [model_select, scenario_select, horizon, output_name]
+        for input_element in inputs:
+            input_element.enable() if enabled else input_element.disable()
+
+    def request_stop():
+        if stop_event and state.is_running:
+            stop_event.set()
+            stop_btn.disable()
+            log_console.push("Stop requested. Waiting for the current safe checkpoint...")
     
     async def update_from_queues():
         """Pull updates from queues and update UI"""
@@ -73,11 +88,14 @@ def render_run_page():
             log_console.push(message)
     
     async def start_run():
-        nonlocal update_timer
+        nonlocal update_timer, stop_event
         
         # Disable run button and set running state (disables navigation buttons)
         run_btn.disable()
+        stop_btn.enable()
+        set_inputs_enabled(False)
         state.is_running = True
+        stop_event = Event()
         progress_bar.set_value(0)
         log_console.clear()
         
@@ -99,7 +117,7 @@ def render_run_page():
             log_console.push("-" * 40)
             
             await run.io_bound(execute_model, models_value, end_year_value,
-                                scenarios_value, output_value, progress_queue, log_queue)
+                                scenarios_value, output_value, progress_queue, log_queue, stop_event)
             
             progress_bar.set_value(1.0)
             log_console.push("-" * 40)
@@ -109,8 +127,12 @@ def render_run_page():
         except Exception as e:
             await update_from_queues()  # flush any pending log messages first
             log_console.push("-" * 40)
-            log_console.push(f"CRITICAL ERROR: {str(e)}")
-            ui.notify('Error', type='negative')
+            if str(e) == "Run cancelled by user":
+                log_console.push("Run cancelled by user.")
+                ui.notify('Run cancelled', type='warning')
+            else:
+                log_console.push(f"CRITICAL ERROR: {str(e)}")
+                ui.notify('Error', type='negative')
         finally:
             # Stop the update timer
             if update_timer:
@@ -118,9 +140,12 @@ def render_run_page():
             # Final update to clear queues
             await update_from_queues()
             run_btn.enable()
+            stop_btn.disable()
+            set_inputs_enabled(True)
             state.is_running = False
+            stop_event = None
 
-def execute_model(models, end_year, scenarios, output_name, progress_queue, log_queue):
+def execute_model(models, end_year, scenarios, output_name, progress_queue, log_queue, stop_event):
     """
     Function to update settings.ini with front end selections,
     call model run, and write output to pickle file.
@@ -141,6 +166,10 @@ def execute_model(models, end_year, scenarios, output_name, progress_queue, log_
     def log_callback(message):
         """Called by model to report log messages"""
         log_queue.put(message)
+
+    def stop_callback():
+        """Called by model to check whether the user requested cancellation."""
+        return stop_event.is_set()
     
     config = configparser.ConfigParser()
     config.read('settings.ini')
@@ -155,7 +184,8 @@ def execute_model(models, end_year, scenarios, output_name, progress_queue, log_
     from ftt_source.model_class import RunFTT
     
     # Create model with callbacks
-    model = RunFTT(progress_callback=progress_callback, log_callback=log_callback)
+    model = RunFTT(progress_callback=progress_callback, log_callback=log_callback,
+                   stop_callback=stop_callback)
     
     log_queue.put("Running model...")
     model.run()

--- a/ftt_source/model_class.py
+++ b/ftt_source/model_class.py
@@ -126,6 +126,7 @@ class RunFTT:
         settings=None,
         progress_callback=None,
         log_callback=None,
+        stop_callback=None,
     ):
         """Instantiate model run object.
 
@@ -153,6 +154,8 @@ class RunFTT:
         log_callback : callable, optional
             Optional callback ``log_callback(message)`` used by GUI wrappers
             for status messages.
+        stop_callback : callable, optional
+            Optional callback returning ``True`` when a GUI run should stop.
         """
         # Configure data paths before any data-loading calls.
         from ftt_source.paths import set_paths, _PACKAGE_ROOT
@@ -183,6 +186,7 @@ class RunFTT:
         self.timeline = np.arange(self.simulation_start, self.simulation_end + 1)
         self.ftt_modules = config.get('settings', 'enable_modules')
         self.scenarios = config.get('settings', 'scenarios')
+        self.stop_callback = stop_callback
 
         # Load classification titles
         self.titles = titles_f.load_titles()
@@ -215,6 +219,11 @@ class RunFTT:
         # Run the solve all method (self.input contains all results)
         self.solve_all()
 
+    def _check_stop_requested(self):
+        """Stop cleanly when the GUI has requested cancellation."""
+        if self.stop_callback and self.stop_callback():
+            raise RuntimeError("Run cancelled by user")
+
     def solve_all(self):
         """ Solve model for each year of the simulation period """
 
@@ -229,6 +238,7 @@ class RunFTT:
             pass
         
         for scen in self.input:
+            self._check_stop_requested()
 
             # Create progress bar:
             with tqdm(self.timeline) as pbar:
@@ -236,6 +246,7 @@ class RunFTT:
             # Call solve_year method for each year of the simulation period
 #                for year_index, year in enumerate(self.timeline):
                 for y, year in enumerate(self.timeline):
+                    self._check_stop_requested()
                     if y == 0:
                         start_time = time.time()
 

--- a/ftt_source/model_class.py
+++ b/ftt_source/model_class.py
@@ -44,6 +44,10 @@ import ftt_source.support.dimensions_functions as dims_f
 from ftt_source.support.cross_section import cross_section as cs
 
 
+class RunCancelledError(RuntimeError):
+    """Raised when a model run is cancelled by the frontend."""
+
+
 class RunFTT:
     """
     Class to run the FTT model.
@@ -222,7 +226,7 @@ class RunFTT:
     def _check_stop_requested(self):
         """Stop cleanly when the GUI has requested cancellation."""
         if self.stop_callback and self.stop_callback():
-            raise RuntimeError("Run cancelled by user")
+            raise RunCancelledError("Run cancelled by user")
 
     def solve_all(self):
         """ Solve model for each year of the simulation period """


### PR DESCRIPTION
Fixes #341.

This PR adds a Stop button next to the Run button so users can cancel a simulation after it has started.

Changes:
- Adds a Stop button while a model run is active.
- Disables the model, scenario, end-year, and output-name controls during a run so users do not change settings that cannot affect the current run.
- Sends a stop request to the running model and cancels at a safe checkpoint.
- Re-enables the controls after the run is cancelled or completed.

Tested locally:
- The Stop button appears while a run is active.
- Clicking Stop logs “Stop requested” and “Run cancelled by user”.
- The controls become usable again after cancellation.